### PR TITLE
Added tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditOutletCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditOutletCommand.java
@@ -41,7 +41,7 @@ public class EditOutletCommand extends UndoableCommand {
 
     public static final String MESSAGE_EDIT_OUTLET_SUCCESS = "Edited Outlet: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_OUTLET = "This outlet already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_OUTLET = "This outlet already exists in the address book.";
     private final Index index;
     private final EditOutletCommand.EditOutletDescriptor editOutletDescriptor;
 
@@ -49,8 +49,8 @@ public class EditOutletCommand extends UndoableCommand {
     private Outlet originalOutlet;
 
     /**
-     * @param index of the person in the outlet list to edit
-     * @param editOutletDescriptor details to edit the person with
+     * @param index of the outlet in the outlet list to edit
+     * @param editOutletDescriptor details to edit the outlet with
      */
     public EditOutletCommand(Index index, EditOutletCommand.EditOutletDescriptor editOutletDescriptor) {
         requireNonNull(index);
@@ -92,7 +92,7 @@ public class EditOutletCommand extends UndoableCommand {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
+     * Creates and returns a {@code Outlet} with the details of {@code outletToEdit}
      * edited with {@code editOutletDescriptor}.
      */
     private static Outlet createEditedOutlet(Outlet outletToEdit, EditOutletDescriptor editOutletDescriptor) {
@@ -130,8 +130,8 @@ public class EditOutletCommand extends UndoableCommand {
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will replace the
-     * corresponding field value of the person.
+     * Stores the details to edit the outlet with. Each non-empty field value will replace the
+     * corresponding field value of the outlet.
      */
     public static class EditOutletDescriptor {
         private OutletName name;
@@ -142,7 +142,6 @@ public class EditOutletCommand extends UndoableCommand {
 
         /**
          * Copy constructor.
-         * A defensive copy of {@code tags} is used internally.
          */
         public EditOutletDescriptor(EditOutletCommand.EditOutletDescriptor toCopy) {
             setName(toCopy.name);

--- a/src/main/java/seedu/address/logic/parser/EditOutletCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditOutletCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditOutletCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -26,7 +25,8 @@ public class EditOutletCommandParser implements Parser<EditOutletCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditOutletCommand.MESSAGE_USAGE),
+                    pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_POSTAL_CODE);
@@ -45,7 +45,7 @@ public class EditOutletCommandParser implements Parser<EditOutletCommand> {
         }
 
         if (!editOutletDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(EditOutletCommand.MESSAGE_NOT_EDITED);
         }
 
         return new EditOutletCommand(index, editOutletDescriptor);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -22,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.outlet.Outlet;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.EditOutletDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.ui.UiAction;
 import seedu.address.ui.content.RightPaneContent;
@@ -88,6 +89,8 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditOutletCommand.EditOutletDescriptor DESC_ALPHA;
+    public static final EditOutletCommand.EditOutletDescriptor DESC_BETA;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -98,6 +101,13 @@ public class CommandTestUtil {
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withPostalCode(VALID_POSTAL_CODE_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+    }
+
+    static {
+        DESC_ALPHA = new EditOutletDescriptorBuilder().withName(VALID_OUTLET_NAME_ALPHA)
+                        .withAddress(VALID_OUTLET_ADDRESS_ALPHA).withPostalCode(VALID_OUTLET_POSTAL_CODE_ALPHA).build();
+        DESC_BETA = new EditOutletDescriptorBuilder().withName(VALID_OUTLET_NAME_BETA)
+                        .withAddress(VALID_OUTLET_ADDRESS_BETA).withPostalCode(VALID_OUTLET_POSTAL_CODE_BETA).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -259,8 +259,6 @@ public class EditCommandTest {
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(SET_FIRST_ENTRY, copyDescriptor);
-        assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
         assertTrue(standardCommand.equals(standardCommand));

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.logic.commands.EditCommand.RIGHT_PANE_HEADER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ENTRY;
 import static seedu.address.testutil.TypicalIndexes.SET_FIRST_ENTRY;
 import static seedu.address.testutil.TypicalIndexes.SET_SECOND_ENTRY;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -100,6 +101,31 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editMultipleCandidates_success() {
+        Set<Index> setMultipleIndexes = Set.of(INDEX_FIRST_ENTRY, INDEX_SECOND_ENTRY);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(setMultipleIndexes, descriptor);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        PersonBuilder firstPersonInList = new PersonBuilder(firstPerson);
+        Person editedFirstPerson = firstPersonInList.withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND).build();
+
+        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_ENTRY.getZeroBased());
+        PersonBuilder secondPersonInList = new PersonBuilder(secondPerson);
+        Person editedSecondPerson = secondPersonInList.withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND).build();
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, 2,
+                Messages.format(editedFirstPerson));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedFirstPerson);
+        expectedModel.setPerson(secondPerson, editedSecondPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel,
+                UiAction.UPDATE_RIGHT_PANE, Optional.of(new PersonContent(editedFirstPerson, RIGHT_PANE_HEADER)));
+    }
+
+    @Test
     public void execute_filteredList_success() throws CommandException {
         model.resetFilteredPersonList();
         showPersonAtIndex(model, INDEX_FIRST_ENTRY);
@@ -123,6 +149,25 @@ public class EditCommandTest {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(SET_SECOND_ENTRY, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_multipleDuplicatePersonUnfilteredList_failure() {
+        Person existingPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(existingPerson).build();
+        Set<Index> setMultipleIndexes = Set.of(INDEX_SECOND_ENTRY, INDEX_THIRD_ENTRY);
+        EditCommand editCommand = new EditCommand(setMultipleIndexes, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_multipleEditDuplicateFields_failure() {
+        Set<Index> setMultipleIndexes = Set.of(INDEX_FIRST_ENTRY, INDEX_SECOND_ENTRY);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        EditCommand editCommand = new EditCommand(setMultipleIndexes, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -22,6 +22,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -44,6 +45,11 @@ import seedu.address.ui.content.PersonContent;
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -98,31 +104,6 @@ public class EditCommandTest {
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel,
                 UiAction.UPDATE_RIGHT_PANE, Optional.of(new PersonContent(editedPerson, RIGHT_PANE_HEADER)));
-    }
-
-    @Test
-    public void execute_editMultipleCandidates_success() {
-        Set<Index> setMultipleIndexes = Set.of(INDEX_FIRST_ENTRY, INDEX_SECOND_ENTRY);
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(setMultipleIndexes, descriptor);
-
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
-        PersonBuilder firstPersonInList = new PersonBuilder(firstPerson);
-        Person editedFirstPerson = firstPersonInList.withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND).build();
-
-        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_ENTRY.getZeroBased());
-        PersonBuilder secondPersonInList = new PersonBuilder(secondPerson);
-        Person editedSecondPerson = secondPersonInList.withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND).build();
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, 2,
-                Messages.format(editedFirstPerson));
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(firstPerson, editedFirstPerson);
-        expectedModel.setPerson(secondPerson, editedSecondPerson);
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel,
-                UiAction.UPDATE_RIGHT_PANE, Optional.of(new PersonContent(editedFirstPerson, RIGHT_PANE_HEADER)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditOutletCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditOutletCommandTest.java
@@ -1,0 +1,162 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_OUTLET_ADDRESS_BETA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_OUTLET_NAME_ALPHA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_OUTLET_NAME_BETA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_OUTLET_POSTAL_CODE_BETA;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditOutletCommand.EditOutletDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.outlet.Outlet;
+import seedu.address.testutil.EditOutletDescriptorBuilder;
+import seedu.address.testutil.OutletBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditOutletCommand.
+ */
+public class EditOutletCommandTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.addOutlet(new OutletBuilder().build());
+    }
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Outlet editedOutlet = new OutletBuilder().build();
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder(editedOutlet).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(INDEX_FIRST_ENTRY, descriptor);
+
+        String expectedMessage = String.format(EditOutletCommand.MESSAGE_EDIT_OUTLET_SUCCESS,
+                Messages.format(editedOutlet));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setOutlet(model.getFilteredOutletList().get(0), editedOutlet);
+
+        assertCommandSuccess(editOutletCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastOutlet = Index.fromOneBased(model.getFilteredOutletList().size());
+        Outlet lastOutlet = model.getFilteredOutletList().get(indexLastOutlet.getZeroBased());
+
+        OutletBuilder outletInList = new OutletBuilder(lastOutlet);
+        Outlet editedOutlet = outletInList.withName(VALID_OUTLET_NAME_ALPHA).build();
+
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder().withName(VALID_OUTLET_NAME_ALPHA).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(indexLastOutlet, descriptor);
+
+        String expectedMessage = String.format(EditOutletCommand.MESSAGE_EDIT_OUTLET_SUCCESS,
+                Messages.format(editedOutlet));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setOutlet(lastOutlet, editedOutlet);
+
+        assertCommandSuccess(editOutletCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditOutletCommand editOutletCommand = new EditOutletCommand(INDEX_FIRST_ENTRY, new EditOutletDescriptor());
+        Outlet editedOutlet = model.getFilteredOutletList().get(INDEX_FIRST_ENTRY.getZeroBased());
+
+        String expectedMessage = String.format(EditOutletCommand.MESSAGE_EDIT_OUTLET_SUCCESS,
+                Messages.format(editedOutlet));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editOutletCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatePersonUnfilteredList_failure() {
+        Outlet validOutlet = new OutletBuilder().withName(VALID_OUTLET_NAME_BETA)
+                .withAddress(VALID_OUTLET_ADDRESS_BETA).withPostalCode(VALID_OUTLET_POSTAL_CODE_BETA).build();
+        model.addOutlet(validOutlet);
+
+        Outlet firstOutlet = model.getFilteredOutletList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder(firstOutlet).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(INDEX_SECOND_ENTRY, descriptor);
+
+        assertCommandFailure(editOutletCommand, model, EditOutletCommand.MESSAGE_DUPLICATE_OUTLET);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredOutletList().size() + 1);
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder().withName(VALID_OUTLET_NAME_ALPHA).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editOutletCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void undo_editCommand_success() throws CommandException {
+        Outlet outletToEdit = model.getFilteredOutletList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        Outlet editedOutlet = new OutletBuilder().withName(VALID_OUTLET_NAME_BETA)
+                .withAddress(VALID_OUTLET_ADDRESS_BETA).withPostalCode(VALID_OUTLET_POSTAL_CODE_BETA).build();
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder(editedOutlet).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(INDEX_FIRST_ENTRY, descriptor);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        editOutletCommand.execute(model);
+        assertFalse(model.hasOutlet(outletToEdit));
+        assertTrue(model.hasOutlet(editedOutlet));
+        model.recordCommand(editOutletCommand);
+
+        model.undo();
+        assertTrue(model.hasOutlet(outletToEdit));
+        assertEquals(expectedModel, model);
+    }
+
+    @Test
+    public void redo_editCommand_success() throws CommandException {
+        Outlet outletToEdit = model.getFilteredOutletList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        Outlet editedOutlet = new OutletBuilder().withName(VALID_OUTLET_NAME_BETA)
+                .withAddress(VALID_OUTLET_ADDRESS_BETA).withPostalCode(VALID_OUTLET_POSTAL_CODE_BETA).build();
+        EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder(editedOutlet).build();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(INDEX_FIRST_ENTRY, descriptor);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        editOutletCommand.execute(model);
+        expectedModel.setOutlet(outletToEdit, editedOutlet);
+        model.recordCommand(editOutletCommand);
+
+        model.undo();
+        model.redo();
+        assertEquals(expectedModel, model);
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditOutletDescriptor editOutletDescriptor = new EditOutletDescriptor();
+        EditOutletCommand editOutletCommand = new EditOutletCommand(index, editOutletDescriptor);
+        String expected = EditOutletCommand.class.getCanonicalName() + "{index=" + index + ", editOutletDescriptor="
+                + editOutletDescriptor + "}";
+        assertEquals(expected, editOutletCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditOutletCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditOutletCommandTest.java
@@ -108,7 +108,7 @@ public class EditOutletCommandTest {
         EditOutletDescriptor descriptor = new EditOutletDescriptorBuilder().withName(VALID_OUTLET_NAME_ALPHA).build();
         EditOutletCommand editOutletCommand = new EditOutletCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editOutletCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editOutletCommand, model, Messages.MESSAGE_INVALID_OUTLET_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditOutletDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditOutletDescriptorBuilder.java
@@ -1,0 +1,61 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditOutletCommand.EditOutletDescriptor;
+import seedu.address.model.outlet.Outlet;
+import seedu.address.model.outlet.OutletAddress;
+import seedu.address.model.outlet.OutletName;
+import seedu.address.model.outlet.OutletPostalCode;
+
+/**
+ * A utility class to help with building EditOutletDescriptor objects.
+ */
+public class EditOutletDescriptorBuilder {
+
+    private EditOutletDescriptor descriptor;
+
+    public EditOutletDescriptorBuilder() {
+        descriptor = new EditOutletDescriptor();
+    }
+
+    public EditOutletDescriptorBuilder(EditOutletDescriptor descriptor) {
+        this.descriptor = new EditOutletDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditOutletDescriptor} with fields containing {@code outlet}'s details
+     */
+    public EditOutletDescriptorBuilder(Outlet outlet) {
+        descriptor = new EditOutletDescriptor();
+        descriptor.setName(outlet.getOutletName());
+        descriptor.setAddress(outlet.getOutletAddress());
+        descriptor.setPostalCode(outlet.getPostalCode());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code EditOutletDescriptor} that we are building.
+     */
+    public EditOutletDescriptorBuilder withName(String name) {
+        descriptor.setName(new OutletName(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code EditOutletDescriptor} that we are building.
+     */
+    public EditOutletDescriptorBuilder withAddress(String address) {
+        descriptor.setAddress(new OutletAddress(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code PostalCode} of the {@code EditOutletDescriptor} that we are building.
+     */
+    public EditOutletDescriptorBuilder withPostalCode(String postalCode) {
+        descriptor.setPostalCode(new OutletPostalCode(postalCode));
+        return this;
+    }
+
+    public EditOutletDescriptor build() {
+        return descriptor;
+    }
+}


### PR DESCRIPTION
Added tests for `EditCommand`:
- Test for editing multiple entries (success)
- Test for editing multiple entries when there exists a duplicate in addressbook (failure) 
- Tests for editing multiple entries such that it would cause a duplicate after editing (eg. editing two entries to have the same phone number) (failure)

Tests for `EditOutletCommand`:
- Test for editing an outlet with all fields specified (success)
- Test for editing an outlet with some fields specified (success)
- Test for editing an outlet with no fields specified (success)
- Test for editing an outlet such that it becomes a duplicate (failure)
- Test for editing an invalid index outlet (failure)
- Test for undoing (success)
- Test for redoing (success)
- Test for toString()

Tests to be added (in a future PR cos I'm tired of this):
Tests for `EditOutletCommand`:
- Test for equals() (This currently does not work for some concerning reason)

Tests for `EditOutletDescripter`:
- Test for equals()
- Test for toString()

I don't really know why the test is failing because I don't see any whitespaces I'm ngl
Closes #90 
Closes #89 